### PR TITLE
Fixed misleading readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To get up and running
 
 1. Clone this repo
 2. `npm install`
-3. `gatsby develop` Gatsby will start a hot-reloading development environment accessible at `localhost:8000`
+3. `npm run develop` Gatsby will start a hot-reloading development environment accessible at `localhost:8000`
 4. Open `src/pages` to edit the application, saved changes will reload in the browser
 
 For an overview of the project structure please refer to the [Gatsby documentation - Building with Components](https://www.gatsbyjs.org/docs/building-with-components/)


### PR DESCRIPTION
@ktrammell95 discovered the "up and running" directions didn't work at all, the project needs gatsby as a local dependency and I forgot to include `npm install`.